### PR TITLE
feat: native game install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "apple-bundle"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9a3a9da7ba0220d2ee5a02b6be5e0dbc73d9e9e74d8ffb5f1a7d32275e7282"
+dependencies = [
+ "plist",
+ "serde",
+ "serde_plain",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +548,7 @@ dependencies = [
 name = "freecarnival"
 version = "0.1.3"
 dependencies = [
+ "apple-bundle",
  "async-channel",
  "async-recursion",
  "base16ct",
@@ -927,6 +939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1178,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "plist"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1227,15 @@ name = "queues"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
+
+[[package]]
+name = "quick-xml"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1405,6 +1449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1530,15 @@ checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ serde_json = "1.0.104"
 sha2 = "0.10.7"
 tokio = { version = "1.31.0", features = ["full"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-bundle = "0.1.4"
+
 [patch.crates-io]
 cookie = { git = "https://github.com/Gustash/cookie-rs.git" }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -93,6 +93,12 @@ pub(crate) enum BuildOs {
     Mac,
 }
 
+impl Default for BuildOs {
+    fn default() -> Self {
+        Self::Windows
+    }
+}
+
 impl std::fmt::Display for BuildOs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -59,22 +59,17 @@ pub(crate) struct Product {
 }
 
 impl Product {
-    pub(crate) fn get_latest_version(&self) -> Option<&String> {
-        let latest_version: Option<&ProductVersion> =
-            self.version.iter().fold(None, |acc, version| match acc {
-                Some(v) => {
-                    if version.date > v.date {
-                        Some(version)
-                    } else {
-                        acc
-                    }
+    pub(crate) fn get_latest_version(&self) -> Option<&ProductVersion> {
+        self.version.iter().fold(None, |acc, version| match acc {
+            Some(v) => {
+                if version.date > v.date {
+                    Some(version)
+                } else {
+                    acc
                 }
-                None => Some(version),
-            });
-        match latest_version {
-            Some(v) => Some(&v.version),
-            None => None,
-        }
+            }
+            None => Some(version),
+        })
     }
 }
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -78,9 +78,29 @@ pub(crate) struct ProductVersion {
     pub(crate) status: u16,
     pub(crate) enabled: u8,
     pub(crate) version: String,
-    pub(crate) os: String,
+    pub(crate) os: BuildOs,
     pub(crate) date: NaiveDateTime,
     pub(crate) text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub(crate) enum BuildOs {
+    #[serde(rename = "win")]
+    Windows,
+    #[serde(rename = "lin")]
+    Linux,
+    #[serde(rename = "mac")]
+    Mac,
+}
+
+impl std::fmt::Display for BuildOs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            BuildOs::Windows => "win",
+            BuildOs::Linux => "lin",
+            BuildOs::Mac => "mac",
+        })
+    }
 }
 
 impl std::fmt::Display for Product {
@@ -96,11 +116,10 @@ impl std::fmt::Display for ProductVersion {
         write!(
             f,
             "Platform: {}",
-            match &self.os[..] {
-                "win" => "Windows",
-                "lin" => "Linux",
-                "mac" => "macOS",
-                os => os,
+            match self.os {
+                BuildOs::Windows => "Windows",
+                BuildOs::Linux => "Linux",
+                BuildOs::Mac => "macOS",
             }
         )?;
         if !self.text.is_empty() {

--- a/src/api/product.rs
+++ b/src/api/product.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer, Deserializer};
 
 use crate::{
     constants::{CONTENT_URL, DEV_URL},
@@ -25,7 +25,7 @@ pub(crate) struct BuildManifestRecord {
     pub(crate) sha: String,
     #[serde(rename = "Flags")]
     pub(crate) flags: u8,
-    #[serde(rename = "File Name")]
+    #[serde(rename = "File Name", deserialize_with = "from_latin1_str", serialize_with = "to_latin1_bytes")]
     pub(crate) file_name: String,
     #[serde(rename = "Change Tag")]
     pub(crate) tag: Option<ChangeTag>,
@@ -45,7 +45,7 @@ impl BuildManifestRecord {
 pub(crate) struct BuildManifestChunksRecord {
     #[serde(rename = "ID")]
     pub(crate) id: u16,
-    #[serde(rename = "Filepath")]
+    #[serde(rename = "Filepath", deserialize_with = "from_latin1_str", serialize_with = "to_latin1_bytes")]
     pub(crate) file_path: String,
     #[serde(rename = "Chunk SHA")]
     pub(crate) sha: String,
@@ -55,7 +55,7 @@ pub(crate) async fn get_build_manifest(
     client: &reqwest::Client,
     product: &Product,
     build_version: &ProductVersion,
-) -> Result<String, reqwest::Error> {
+) -> Result<Bytes, reqwest::Error> {
     let res = client
         .get(format!(
             "{}/DevShowCaseSourceVolume/dev_fold_{}/{}/{}/{}_manifest.csv",
@@ -67,7 +67,7 @@ pub(crate) async fn get_build_manifest(
         ))
         .send()
         .await?;
-    let body = res.text().await?;
+    let body = res.bytes().await?;
     Ok(body)
 }
 
@@ -75,7 +75,7 @@ pub(crate) async fn get_build_manifest_chunks(
     client: &reqwest::Client,
     product: &Product,
     build_version: &ProductVersion,
-) -> Result<String, reqwest::Error> {
+) -> Result<Bytes, reqwest::Error> {
     let res = client
         .get(format!(
             "{}/DevShowCaseSourceVolume/dev_fold_{}/{}/{}/{}_manifest_chunks.csv",
@@ -87,7 +87,7 @@ pub(crate) async fn get_build_manifest_chunks(
         ))
         .send()
         .await?;
-    let body = res.text().await?;
+    let body = res.bytes().await?;
     Ok(body)
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,7 +135,7 @@ pub(crate) enum Commands {
         /// The WINE bin to use for launching the game
         #[cfg(not(target_os = "windows"))]
         #[arg(long)]
-        wine_bin: PathBuf,
+        wine_bin: Option<PathBuf>,
     },
     /// Print info about game
     Info {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,11 +96,32 @@ async fn main() {
                 (None, Some(base_path)) => base_path.join(&slug),
                 (None, None) => DEFAULT_BASE_INSTALL_PATH.join(&slug),
             };
+
+            let library = LibraryConfig::load().expect("Failed to load library");
+            let selected_version = match (
+                version,
+                library.collection.iter().find(|p| p.slugged_name == slug),
+            ) {
+                (Some(version), Some(product)) => {
+                    match product.version.iter().find(|v| v.version == version) {
+                        Some(version) => Some(version),
+                        None => {
+                            println!("Couldn't find build {version} for {slug}");
+                            return;
+                        }
+                    }
+                }
+                (_, None) => {
+                    println!("{slug} is not in your library");
+                    return;
+                }
+                _ => None,
+            };
             match utils::install(
                 client.clone(),
                 &slug,
                 &install_path,
-                version,
+                selected_version,
                 max_download_workers,
                 max_memory_usage,
                 info,
@@ -198,13 +219,32 @@ async fn main() {
                 }
             };
             let library = LibraryConfig::load().expect("Failed to load library");
+            let selected_version = match (
+                version,
+                library.collection.iter().find(|p| p.slugged_name == slug),
+            ) {
+                (Some(version), Some(product)) => {
+                    match product.version.iter().find(|v| v.version == version) {
+                        Some(version) => Some(version),
+                        None => {
+                            println!("Couldn't find build {version} for {slug}");
+                            return;
+                        }
+                    }
+                }
+                (_, None) => {
+                    println!("{slug} is not in your library");
+                    return;
+                }
+                _ => None,
+            };
 
             match utils::update(
                 client.clone(),
-                library,
+                &library,
                 &slug,
                 &install_info,
-                version,
+                selected_version,
                 max_download_workers,
                 max_memory_usage,
                 info,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,10 +129,10 @@ async fn main() {
             )
             .await
             {
-                Ok(Ok((info, Some(installed_version)))) => {
+                Ok(Ok((info, Some(install_info)))) => {
                     println!("{}", info);
 
-                    installed.insert(slug, InstallInfo::new(install_path, installed_version));
+                    installed.insert(slug, install_info);
                     installed
                         .store()
                         .expect("Failed to update installed config");
@@ -252,11 +252,11 @@ async fn main() {
             )
             .await
             {
-                Ok((info, Some(installed_version))) => {
+                Ok((info, Some(install_info))) => {
                     println!("{}", info);
                     installed.insert(
                         slug,
-                        InstallInfo::new(install_info.install_path, installed_version),
+                        install_info,
                     );
                     installed
                         .store()

--- a/src/shared/models.rs
+++ b/src/shared/models.rs
@@ -11,6 +11,7 @@ pub(crate) struct InstallInfo {
     /// Version of the game that is installed
     pub(crate) version: String,
     /// OS the build is for
+    #[serde(default)]
     pub(crate) os: BuildOs,
 }
 

--- a/src/shared/models.rs
+++ b/src/shared/models.rs
@@ -2,19 +2,24 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::api::auth::BuildOs;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct InstallInfo {
     /// Directory where game was installed to
     pub(crate) install_path: PathBuf,
     /// Version of the game that is installed
     pub(crate) version: String,
+    /// OS the build is for
+    pub(crate) os: BuildOs,
 }
 
 impl InstallInfo {
-    pub(crate) fn new(install_path: PathBuf, version: String) -> InstallInfo {
+    pub(crate) fn new(install_path: PathBuf, version: String, os: BuildOs) -> InstallInfo {
         InstallInfo {
             install_path,
             version,
+            os,
         }
     }
 }


### PR DESCRIPTION
## Changes

This PR allows for installing native Linux and macOS games. It also allows for launching the native macOS game from the program itself.

## Notes

Due to limitations on IndieGala's API, we have no way of knowing that the actual executable for Linux is, so the program will not be able to launch Linux games. You should be able to go to the install folder and run the game manually.